### PR TITLE
Install AWS CLI v2 instead of v1

### DIFF
--- a/src/userdata.sh
+++ b/src/userdata.sh
@@ -169,9 +169,13 @@ set -g status-right '%H:%M:%S'
 set-option -g window-size smallest
 EOF_
 
-# Install AWS CLI
+# Install AWS CLI v2
 
-apt install awscli -y
+apt install unzip -y
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+rm -rf awscliv2.zip aws
 
 # Install Terraform
 


### PR DESCRIPTION
Install AWS CLI v2 instead of v1 following official instrucions, since v1 is deprecated